### PR TITLE
calendar#423 fixed the video conference button displaying too close to the note field and having slight left padding as an attendee

### DIFF
--- a/src/linagora.esn.videoconference.calendar/app/components/calendar-videoconference-form/calendar-videoconference.less
+++ b/src/linagora.esn.videoconference.calendar/app/components/calendar-videoconference-form/calendar-videoconference.less
@@ -50,3 +50,28 @@
     margin-right: 16px;
   }
 }
+
+.video-conference-no-edit {
+  .flex-vertical-centered;
+
+  margin-bottom: 10px;
+
+  span.icon {
+    cursor: help;
+    font-size: 1.9em;
+    padding-right: 10px;
+  }
+
+  .meta {
+    padding-left: 12px;
+
+    .separator {
+      display: inline;
+      margin: 0px 3px;
+    }
+
+    .separator:first-child {
+      display: none;
+    }
+  }
+}

--- a/src/linagora.esn.videoconference.calendar/app/components/calendar-videoconference-form/calendar-videoconference.pug
+++ b/src/linagora.esn.videoconference.calendar/app/components/calendar-videoconference-form/calendar-videoconference.pug
@@ -36,7 +36,7 @@
               | {{ 'Copy link' | translate }}
 
   // Case user cannot modify the event
-  .col-xs-12.cal-event-form-organizer(ng-if="!$ctrl.canModifyEvent && $ctrl.videoconference() === $ctrl.videoconferenceOptions.OPENPAAS_VIDEOCONFERENCE")
+  .col-xs-12.video-conference-no-edit(ng-if="!$ctrl.canModifyEvent && $ctrl.videoconference() === $ctrl.videoconferenceOptions.OPENPAAS_VIDEOCONFERENCE")
     span.icon
       md-tooltip(md-direction="bottom" md-z-index="10000")
         span {{ 'Video conference' | translate }}


### PR DESCRIPTION
## before

![image](https://user-images.githubusercontent.com/6764881/108958773-baaabb80-7673-11eb-8b2c-edbc90188a21.png)

## after

![image](https://user-images.githubusercontent.com/6764881/108959089-3573d680-7674-11eb-8af6-0ea6195bcc94.png)

closes https://github.com/OpenPaaS-Suite/esn-frontend-calendar/issues/423
